### PR TITLE
Add prometheus exporter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "UT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
   digest = "1:36fe9527deed01d2a317617e59304eb2c4ce9f8a24115bcc5c2e37b3aee5bae4"
   name = "github.com/gin-contrib/sse"
   packages = ["."]
@@ -82,6 +90,14 @@
   version = "v0.0.4"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "UT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -98,6 +114,50 @@
   version = "1.0.1"
 
 [[projects]]
+  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "UT"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:2d5cd61daa5565187e1d96bae64dbbc6080dacf741448e9629c64fd93203b0d4"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "UT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:63b68062b8968092eb86bedc4e68894bd096ea6b24920faca8b9dcf451f54bb5"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "UT"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ef74914912f99c79434d9c09658274678bc85080ebe3ab32bec3940ebce5e1fc"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "UT"
+  revision = "185b4288413d2a0dd0806f78c90dde719829e5ae"
+
+[[projects]]
   digest = "1:03aa6e485e528acb119fb32901cf99582c380225fc7d5a02758e08b180cb56c3"
   name = "github.com/ugorji/go"
   packages = ["codec"]
@@ -106,9 +166,18 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:65abb17699dcf57c6744a0a422f94a698d4afc76b2a4582a9cff6e1d75a9c941"
+  digest = "1:e58ea87007791c8f6fd58bf13866e13125800483fcfae45d1ec22cebe79a078e"
   name = "go.opencensus.io"
-  packages = ["."]
+  packages = [
+    ".",
+    "exporter/prometheus",
+    "internal",
+    "internal/tagencoding",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+  ]
   pruneopts = "UT"
   revision = "79993219becaa7e29e3b60cb67f5b8e82dee11d6"
   version = "v0.17.0"
@@ -153,7 +222,8 @@
     "github.com/jinzhu/gorm",
     "github.com/jinzhu/gorm/dialects/mysql",
     "github.com/joho/godotenv",
-    "go.opencensus.io",
+    "github.com/prometheus/client_golang/prometheus",
+    "go.opencensus.io/exporter/prometheus",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -6,3 +6,9 @@ services:
             - 3306:3306
         volumes:
             - ./.docker/volumes/mysql:/var/lib/mysql
+
+    prometheus:
+        ports:
+            - 9090:9090
+        volumes:
+            - ./.docker/volumes/prometheus:/prometheus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,20 @@ services:
         environment:
             MYSQL_ROOT_PASSWORD: root
             MYSQL_DATABASE: database
+
+    prometheus:
+        image: prom/prometheus:v2.4.3
+        command:
+            - '--config.file=/etc/prometheus/prometheus.yaml'
+            - '--storage.tsdb.path=/prometheus'
+        volumes:
+            - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+        depends_on:
+            - dockerhost
+
+    dockerhost:
+        image: qoomon/docker-host
+        cap_add:
+            - NET_ADMIN
+            - NET_RAW
+        restart: on-failure

--- a/main.go
+++ b/main.go
@@ -7,10 +7,20 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/mysql" // blank import is used here for simplicity
+	prom "github.com/prometheus/client_golang/prometheus"
 	"github.com/sagikazarmark/go-gin-gorm-opencensus/internal"
+	"go.opencensus.io/exporter/prometheus"
 )
 
 func main() {
+	// Create prometheus exporter
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		Registry: prom.DefaultGatherer.(*prom.Registry),
+	})
+	if err != nil {
+		panic(err)
+	}
+
 	// Connect to database
 	dsn := fmt.Sprintf(
 		"%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&parseTime=True",
@@ -38,6 +48,9 @@ func main() {
 	// Add routes
 	r.POST("/people", internal.CreatePerson(db))
 	r.GET("/hello/:firstName", internal.Hello(db))
+	r.GET("/metrics", gin.HandlerFunc(func(c *gin.Context) {
+		pe.ServeHTTP(c.Writer, c.Request)
+	}))
 
 	// Listen and serve on 0.0.0.0:8080
 	r.Run()

--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -1,0 +1,13 @@
+global:
+    scrape_interval: 10s
+
+    external_labels:
+        monitor: 'demo'
+
+scrape_configs:
+    - job_name: 'demo'
+
+      scrape_interval: 10s
+
+      static_configs:
+          - targets: ['dockerhost:8080']


### PR DESCRIPTION
Add prometheus exporter to the application and a prometheus instance to the development environment based on the [official OpenCensus documentation](https://opencensus.io/guides/exporters/supported-exporters/go/prometheus/).